### PR TITLE
Correct AF_LORA to be consisten with the value in kernel

### DIFF
--- a/include/linux/lora.h
+++ b/include/linux/lora.h
@@ -1,6 +1,6 @@
 #include "../../linux/include/uapi/linux/lora.h"
 
-#define AF_LORA 28
+#define AF_LORA 45
 #define PF_LORA AF_LORA
 
 #define ARPHRD_LORA 827


### PR DESCRIPTION
The original AF_LORA ist 28 which is not consistent with the value 45 in kernel.
This patch will fix the problem and now test programs like nltest is working properly.

Signed-off-by: Xue Liu <liuxuenetmail@gmail.com>